### PR TITLE
makes async code simpler and robuster

### DIFF
--- a/src/org/zalando/stups/magnificent/api.clj
+++ b/src/org/zalando/stups/magnificent/api.clj
@@ -183,7 +183,7 @@
           (let [accounts-channel (chan)
                 nr-of-accounts   (count accounts)
                 chan-seq!!       (fn chan-seq!! [ch]
-                                   (when-let [v (<!! ch)] (cons v (chan-seq!! ch))))]
+                                   (lazy-seq (when-let [v (<!! ch)] (cons v (chan-seq!! ch)))))]
             (when (zero? nr-of-accounts)
               ; no accounts to look through
               (log/info "Access rejected: %s" {:reason "Not a team member and team has no accounts" :team team :member-id member-id})


### PR DESCRIPTION
Previously the code will block forever, when there's an exception thrown in `org.zalando.stups.magnificent.external.account/get-account` within `org.zalando.stups.magnificent.api/post-auth`

This PR fixes this and simplifies the code
