### PR TITLE
Update .zappr.yaml

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -10,4 +10,4 @@ approvals:
   # Allow last committer / PR creator to approve as well.
   # This will probably become the default in zappr.
   ignore: none
-X-Zalando-Team: "stups"
+X-Zalando-Team: "foundation"


### PR DESCRIPTION
Handover to team "foundation", in order to shut down the virtual "stups" team.